### PR TITLE
PCI-2572 Relax the version constrain when trying to upload packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 pkginfo = "*"
 twine = "*"
 pip = "==20.2.4"
-pep440 = "*"
 setuptools = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9c867cdf21e3b02cc4c962c668a692a4299f8cbeb2a8b39d09f1b1cc972ad73b"
+            "sha256": "b2726239b05e716236e21318c3f2a7b202d61590b7a23055fe871236dac7f18a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -92,7 +92,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==2.0.12"
         },
         "commonmark": {
@@ -143,7 +143,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_version >= '3.5'",
+            "markers": "python_full_version >= '3.5.0'",
             "version": "==3.3"
         },
         "importlib-metadata": {
@@ -169,14 +169,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==23.6.0"
-        },
-        "pep440": {
-            "hashes": [
-                "sha256:9b51ffcaaa83885ae3ead983f63a3c9c36a40816719013eafc7b52397307e194",
-                "sha256:cebc1a29a7a20ee60c7fcb25a7a1c71c4c5efa7782f8f96f0f7840bed40c6bf3"
-            ],
-            "index": "pypi",
-            "version": "==0.1.0"
         },
         "pip": {
             "hashes": [
@@ -223,7 +215,7 @@
                 "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f",
                 "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"
             ],
-            "markers": "python_version >= '3.7' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.0"
         },
         "requests-toolbelt": {
@@ -246,7 +238,7 @@
                 "sha256:4c586de507202505346f3e32d1363eb9ed6932f0c2f63184dea88983ff4971e2",
                 "sha256:d2bbd99c320a2532ac71ff6a3164867884357da3e3301f0240090c5d2fdac7ec"
             ],
-            "markers": "python_full_version >= '3.6.3' and python_full_version < '4.0.0'",
+            "markers": "python_version < '4' and python_full_version >= '3.6.3'",
             "version": "==12.4.4"
         },
         "secretstorage": {
@@ -286,7 +278,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.9"
         },
         "webencodings": {

--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -56,12 +56,15 @@ def upload_package(pkgpath, input):
         'TWINE_REPOSITORY_URL': url
     })
 
-    subprocess.run(
-        twine_cmd,
-        stdout=sys.stderr.fileno(),
-        check=True,
-        env=env
-    )
+    try:
+        subprocess.run(
+            twine_cmd,
+            stdout=sys.stderr.fileno(),
+            check=True,
+            env=env
+        )
+    except subprocess.CalledProcessError as e:
+        raise SystemExit(e.returncode)
 
 
 def out(srcdir, input):

--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -82,10 +82,11 @@ def out(srcdir, input):
         )
 
     try:
-        pipio.Version(str(version))
+        pipio.Version(version)
     except pipio.InvalidVersion:
         raise VersionValidationError(
-            f"Version {version} string is not compliant with PEP 440 versioning convention"
+            f"Version {version} string is not compliant with PEP 440 versioning convention.",
+            "See https://peps.python.org/pep-0440 for more details."
         )
 
     common.msg('Uploading {} version {}', pkgpath, version)

--- a/pypi_resource/out.py
+++ b/pypi_resource/out.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 
 from . import common, pipio
-from pep440 import is_canonical
 
 class VersionValidationError(Exception):
     pass
@@ -81,7 +80,10 @@ def out(srcdir, input):
         raise NamesValidationError(
             f"Different names for package ({package_name}) and input ({input_name}). If this is intentional, you can configure `name_must_match` to `false`."
         )
-    if not is_canonical(version):
+
+    try:
+        pipio.Version(str(version))
+    except pipio.InvalidVersion:
         raise VersionValidationError(
             f"Version {version} string is not compliant with PEP 440 versioning convention"
         )


### PR DESCRIPTION
- out: relax the version constrain when trying to upload packages

It basically uses a wrapper for `packaging.version` that exists in the `pipio.py` code and is used also in the `in` and `check` steps to determine the version. So any version valid for `packaging.version` (and pip) should be valid for the resource.

This will enables us to ensure that any version put by the resource can also be fetched by both the resource and pip. Currently the resource is too restrictive in the put step because it does not allow `1.2.3.dev10+g123abc45` which is a valid pep440 version.
