### PR TITLE
Fix master pipeline

### DIFF
--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -161,8 +161,6 @@ jobs:
     inputs: [image, version]
     params:
       image: image/image.tar
-      additional_tags: ((docker_tag_add_file))
-      
 
 - name: pypi-acceptance-test
   <<: *base-job

--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -170,16 +170,12 @@ jobs:
   - get: pypi-wheel-example
     trigger: false
   - get: version
-    params:
-      bump: "minor"
   - put: cogito
     inputs: [pypi.git]
     params: {state: pending}
   - task: build-example-wheel
     image: python.docker
-    file: pypi.git/ci/tasks/build-example-wheel.yml 
-  - put: version
-    params: {file: version/version}
+    file: pypi.git/ci/tasks/build-example-wheel.yml
   - put: pix4d-pypi
     inputs:
       - dist
@@ -189,7 +185,6 @@ jobs:
 - name: publish-concourse-pypi-resource
   <<: *base-job
   plan:
-  - get: linux-builder.git
   - get: pypi.git
   - get: version
     params:
@@ -199,11 +194,8 @@ jobs:
     passed: [pypi-acceptance-test]
     params:
       format: oci
-  - task: config-create
-    file: linux-builder.git/ci/tasks/config-create.yml
-    params:
-      REPOSITORY: docker.ci.pix4d.com/concourse-pypi-resource
   - put: version
+    params: {file: version/version}
   - put: pypi.docker
     inputs: [pypi.dev-docker, version]
     params:

--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -65,7 +65,7 @@ resources:
 - name: pix4d-pypi
   type: pypi.test
   source:
-    name: concourse.example
+    name: test-package1
     packaging: any
     pre_release: true
     repository:
@@ -74,13 +74,6 @@ resources:
       password: ((concourse_artifactory_password))
       index_url: https://artifactory.ci.pix4d.com/artifactory/api/pypi/pix4d-pypi-dev-local/simple
       repository_url: https://artifactory.ci.pix4d.com/artifactory/api/pypi/pix4d-pypi-dev-local
-
-- name: pypi-wheel-example
-  type: git
-  source:
-    uri: git@github.com:pix4d/concourse-examples.git
-    branch: master
-    private_key: ((github_ssh_key))
 
 - name: pypi.git
   icon: git
@@ -167,8 +160,6 @@ jobs:
     passed: [concourse-pypi-resource-build]
   - get: pypi.git
   - get: python.docker
-  - get: pypi-wheel-example
-    trigger: false
   - get: version
   - put: cogito
     inputs: [pypi.git]

--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -114,8 +114,8 @@ resources:
   type: semver
   source:
     driver: s3
-    initial_version: 0.0.1
-    key: artifacts/concourse-example-pypi/version
+    initial_version: ((semver_initial_version))
+    key: ((semver_key))
     <<: *s3-params
 
 jobs:
@@ -141,13 +141,10 @@ jobs:
     passed: [concourse-pypi-resource-unit-tests]
   - get: linux-builder.git
   - get: python.docker
+  - get: version
   - put: cogito
     inputs: [pypi.git]
     params: {state: pending}
-  - task: config-create
-    file: linux-builder.git/ci/tasks/config-create.yml
-    params:
-      REPOSITORY: docker.ci.pix4d.com/concourse-pypi-resource
   - task: build-wheel
     image: python.docker
     file: pypi.git/ci/tasks/build-wheel.yml
@@ -194,6 +191,9 @@ jobs:
   plan:
   - get: linux-builder.git
   - get: pypi.git
+  - get: version
+    params:
+      bump: patch
   - get: pypi.dev-docker
     trigger: ((trigger))
     passed: [pypi-acceptance-test]
@@ -203,6 +203,7 @@ jobs:
     file: linux-builder.git/ci/tasks/config-create.yml
     params:
       REPOSITORY: docker.ci.pix4d.com/concourse-pypi-resource
+  - put: version
   - put: pypi.docker
     inputs: [pypi.dev-docker, version]
     params:

--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -161,6 +161,7 @@ jobs:
     inputs: [image, version]
     params:
       image: image/image.tar
+      additional_tags: ((docker_tag_add_file))
       
 
 - name: pypi-acceptance-test
@@ -193,12 +194,19 @@ jobs:
 - name: publish-concourse-pypi-resource
   <<: *base-job
   plan:
+  - get: linux-builder.git
+  - get: pypi.git
   - get: pypi.dev-docker
     trigger: ((trigger))
     passed: [pypi-acceptance-test]
     params:
       format: oci
+  - task: config-create
+    file: linux-builder.git/ci/tasks/config-create.yml
+    params:
+      REPOSITORY: docker.ci.pix4d.com/concourse-pypi-resource
   - put: pypi.docker
+    inputs: [pypi.dev-docker, version]
     params:
       image: pypi.dev-docker/image.tar
       additional_tags: ((docker_tag_add_file))

--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -155,7 +155,7 @@ jobs:
       CONTEXT: repo/
     input_mapping: {repo: wheel}
   - put: pypi.dev-docker
-    inputs: [image, version]
+    inputs: [image]
     params:
       image: image/image.tar
 

--- a/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
+++ b/ci/pipelines/concourse-pypi-resource-pipeline-template.yml
@@ -191,6 +191,7 @@ jobs:
       glob: 'dist/*'
 
 - name: publish-concourse-pypi-resource
+  <<: *base-job
   plan:
   - get: pypi.dev-docker
     trigger: ((trigger))

--- a/ci/settings/feature-branch.yml
+++ b/ci/settings/feature-branch.yml
@@ -1,7 +1,7 @@
 project: concourse-pypi-resource-pipeline
 docker_tag_add_file:
 semver_initial_version: 0.0.0
-semver_key: artifacts/concourse-example-pypi-dev/version
+semver_key: artifacts/concourse-pypi-resource/version
 pci-gchat_hook: ((gchat_hook_sandobox_integration_team))
 trigger: false
 team: developers

--- a/ci/settings/feature-branch.yml
+++ b/ci/settings/feature-branch.yml
@@ -1,5 +1,7 @@
 project: concourse-pypi-resource-pipeline
 docker_tag_add_file:
+semver_initial_version: 0.0.0
+semver_key: artifacts/concourse-example-pypi-dev/version
 pci-gchat_hook: ((gchat_hook_sandobox_integration_team))
 trigger: false
 team: developers

--- a/ci/settings/master-branch.yml
+++ b/ci/settings/master-branch.yml
@@ -2,7 +2,7 @@ project: concourse-pypi-resource-pipeline
 docker_tag: latest
 docker_tag_add_file: version/version
 semver_initial_version: 0.9.0
-semver_key: artifacts/concourse-example-pypi/version
+semver_key: final/concourse-pypi-resource/version
 branch: master
 trigger: true
 pci-gchat_hook: ((gchat_hook_integration_team))

--- a/ci/settings/master-branch.yml
+++ b/ci/settings/master-branch.yml
@@ -1,4 +1,4 @@
-project: concourse-pypi-resource-pipeline-template
+project: concourse-pypi-resource-pipeline
 docker_tag: latest
 docker_tag_add_file: version/date.txt
 branch: master

--- a/ci/settings/master-branch.yml
+++ b/ci/settings/master-branch.yml
@@ -1,6 +1,8 @@
 project: concourse-pypi-resource-pipeline
 docker_tag: latest
-docker_tag_add_file: version/date.txt
+docker_tag_add_file: version/version
+semver_initial_version: 0.9.0
+semver_key: artifacts/concourse-example-pypi/version
 branch: master
 trigger: true
 pci-gchat_hook: ((gchat_hook_integration_team))

--- a/ci/tasks/build-example-wheel.yml
+++ b/ci/tasks/build-example-wheel.yml
@@ -1,7 +1,7 @@
 platform: linux
 
 inputs:
-  - name: pypi-wheel-example
+  - name: pypi.git
   - name: version
 
 outputs:
@@ -13,6 +13,6 @@ run:
   - -exc
   - |
     export VERSION=`cat version/version`
-    cd pypi-wheel-example/example/pypi
+    cd pypi.git/test/test_package1_3
     python setup.py bdist_wheel
     mv dist/*.whl ../../../dist/  


### PR DESCRIPTION
```
ERRO[0000] could not parse additional tags: failed to read file at "/tmp/build/put/version/date.txt": open /tmp/build/put/version/date.txt: no such file or directory 
```

This error raised after merging, didn't catch this copy/paste leftover while working on the feature.

Besides that, and following the comments I received, I use the `semver` Concourse resource for adding additional tag, discarding the task `create config` that is not needed anymore.